### PR TITLE
Update private_predict for tf-encrypted>0.5.5

### DIFF
--- a/private_predict
+++ b/private_predict
@@ -136,8 +136,8 @@ if config.plaintext:
 
 else:
   logger.info('running prediction securely')
-  c = tfe.convert.convert.Converter()
-  y = c.convert(graph_def, tfe.convert.registry(), 'input-provider', inputs)
+  c = tfe.convert.convert.Converter(tfe.convert.registry())
+  y = c.convert(graph_def, 'input-provider', inputs)
 
   def reveal_output(sess, y, feed_dict):
     run_op = y.reveal()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastai==1.0.51
 tensorflow==1.13.1
-tf_encrypted>=0.5.4<=0.5.5
+tf_encrypted>=0.5.6


### PR DESCRIPTION
**Note:** This PR should only be merged once tf-encrypted 0.5.6 is released.

The Converter API has changed in tf-encrypted/tf-encrypted#570, so this pull request updates this example and pins the version to `tf-encrypted>=0.5.6`.  I also created a tag `v0.1` so that users of 0.5.4 & 0.5.5 can still run the example.